### PR TITLE
Add worker rating and block

### DIFF
--- a/prisma/migrations/20240416013657_add_worker_rating/migration.sql
+++ b/prisma/migrations/20240416013657_add_worker_rating/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ShiftAssignment" ADD COLUMN     "rating" INTEGER;

--- a/prisma/migrations/20240416013813_add_blocked_workers/migration.sql
+++ b/prisma/migrations/20240416013813_add_blocked_workers/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "BlockedWorker" (
+    "shiftUuid" TEXT NOT NULL,
+    "workerUuid" TEXT NOT NULL,
+    "facilityUuid" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "blockReason" TEXT NOT NULL,
+
+    CONSTRAINT "BlockedWorker_pkey" PRIMARY KEY ("facilityUuid","workerUuid")
+);
+
+-- AddForeignKey
+ALTER TABLE "BlockedWorker" ADD CONSTRAINT "BlockedWorker_shiftUuid_fkey" FOREIGN KEY ("shiftUuid") REFERENCES "Shift"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BlockedWorker" ADD CONSTRAINT "BlockedWorker_workerUuid_fkey" FOREIGN KEY ("workerUuid") REFERENCES "Worker"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BlockedWorker" ADD CONSTRAINT "BlockedWorker_facilityUuid_fkey" FOREIGN KEY ("facilityUuid") REFERENCES "HealthCareFacility"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,16 +11,18 @@ datasource db {
 }
 
 model HealthCareFacility {
-  uuid   String  @id @default(uuid())
-  shifts Shift[]
-  name   String
+  uuid           String          @id @default(uuid())
+  shifts         Shift[]
+  name           String
+  blockedWorkers BlockedWorker[]
 }
 
 model Worker {
-  uuid             String            @id @default(uuid())
-  shiftAssignments ShiftAssignment[]
-  firstName        String
-  lastName         String
+  uuid                String            @id @default(uuid())
+  shiftAssignments    ShiftAssignment[]
+  firstName           String
+  lastName            String
+  blockedAtFacilities BlockedWorker[]
 }
 
 model Shift {
@@ -35,6 +37,7 @@ model Shift {
   startTime        DateTime
   endTime          DateTime
   workerSlots      Int
+  blockedWorkers BlockedWorker[]
 }
 
 model ShiftAssignment {
@@ -42,6 +45,20 @@ model ShiftAssignment {
   workerUuid String
   shift      Shift  @relation(fields: [shiftUuid], references: [uuid])
   worker     Worker @relation(fields: [workerUuid], references: [uuid])
+  rating     Int?
 
   @@id([shiftUuid, workerUuid])
+}
+
+model BlockedWorker {
+  shiftUuid    String
+  workerUuid   String
+  facilityUuid String
+  shift        Shift              @relation(fields: [shiftUuid], references: [uuid])
+  worker       Worker             @relation(fields: [workerUuid], references: [uuid])
+  facility     HealthCareFacility @relation(fields: [facilityUuid], references: [uuid])
+  createdAt    DateTime
+  blockReason  String
+
+  @@id([facilityUuid, workerUuid])
 }

--- a/src/core/shiftManagement.ts
+++ b/src/core/shiftManagement.ts
@@ -9,6 +9,10 @@ import { prisma } from "../prismaClient";
 
 type Timestamps = "createdAt" | "updatedAt";
 
+type GenericSuccessResponse = {
+  status: "ok";
+}
+
 export function listAllShifts(): Promise<Shift[]> {
   return prisma.shift.findMany();
 }
@@ -16,7 +20,10 @@ export function listAllShifts(): Promise<Shift[]> {
 export function listHealthCareFacilityShifts(
   facilityUuid: HealthCareFacility["uuid"],
 ): Promise<Shift[]> {
-  return prisma.shift.findMany({ where: { facilityUuid } });
+  return prisma.shift.findMany({
+    where: { facilityUuid },
+    include: { shiftAssignments: true },
+  });
 }
 
 export function listWorkerShifts(
@@ -54,4 +61,48 @@ export function applyToShift(
       worker: { connect: { uuid: workerUuid } },
     },
   });
+}
+
+export function rateWorker(
+  workerUuid: Worker["uuid"],
+  shiftUuid: Shift["uuid"],
+  rating: number,
+): Promise<ShiftAssignment> {
+  return prisma.shiftAssignment.update({
+    where: {
+      shiftUuid_workerUuid: {
+        shiftUuid,
+        workerUuid,
+      },
+    },
+    data: { rating },
+  });
+}
+
+export async function blockWorker(
+  workerUuid: Worker["uuid"],
+  shiftUuid: Shift["uuid"],
+  blockReason: string,
+): Promise<GenericSuccessResponse> {
+  const shift = await prisma.shift.findUniqueOrThrow({
+    where: {
+      uuid: shiftUuid,
+    },
+  });
+  const facility = await prisma.healthCareFacility.findUniqueOrThrow({
+    where: {
+      uuid: shift.facilityUuid,
+    },
+  });
+  await prisma.blockedWorker.create({
+    data: {
+      facilityUuid: facility.uuid,
+      shiftUuid,
+      workerUuid,
+      blockReason,
+      createdAt: new Date(),
+    },
+  });
+
+  return { status: "ok" };
 }

--- a/src/rest/v1/index.ts
+++ b/src/rest/v1/index.ts
@@ -6,10 +6,12 @@ import {
 } from "../../core/facilityManagement";
 import {
   applyToShift,
+  blockWorker,
   createShift,
   listAllShifts,
   listHealthCareFacilityShifts,
   listWorkerShifts,
+  rateWorker,
 } from "../../core/shiftManagement";
 import { createWorker, listWorkers } from "../../core/workerManagement";
 
@@ -57,8 +59,8 @@ v1.post(workersBase, async (req, res) => {
 });
 
 v1.get(`${workersBase}/:uuid/shifts`, async (req, res) => {
-  const shifts = await listWorkerShifts(req.params.uuid);
-  res.send(JSON.stringify({ shifts }));
+  const shiftAssignments = await listWorkerShifts(req.params.uuid);
+  res.send(JSON.stringify({ shiftAssignments }));
 });
 
 v1.post(`${workersBase}/:uuid/shifts`, async (req, res) => {
@@ -74,4 +76,18 @@ const shiftsBase = "/shifts";
 v1.get(shiftsBase, async (req, res) => {
   const shifts = await listAllShifts();
   res.send(JSON.stringify({ shifts }));
+});
+
+// Ratings
+v1.post("/rate-worker", async (req, res) => {
+  const { workerUuid, shiftUuid, rating } = req.body;
+  const shiftAssignment = await rateWorker(workerUuid, shiftUuid, rating);
+  res.send(JSON.stringify({ shiftAssignment }));
+});
+
+// Block workers
+v1.post("/block-worker", async (req, res) => {
+  const { workerUuid, shiftUuid, blockReason } = req.body;
+  const result = await blockWorker(workerUuid, shiftUuid, blockReason);
+  res.send(JSON.stringify(result));
 });

--- a/src/rest/v1/openapi.yml
+++ b/src/rest/v1/openapi.yml
@@ -113,6 +113,8 @@ components:
           type: string
         workerUuid:
           type: string
+        rating:
+          type: number
         shift:
           $ref: '#/components/schemas/Shift'
         worker:
@@ -127,6 +129,39 @@ components:
           type: string
       required:
         - shiftUuid
+    RateWorkerInput:
+      type: object
+      properties:
+        shiftUuid:
+          type: string
+        workerUuid:
+          type: string
+        rating:
+          type: integer
+      required:
+        - shiftUuid
+        - workerUuid
+        - rating
+    BlockWorkerInput:
+      type: object
+      properties:
+        shiftUuid:
+          type: string
+        workerUuid:
+          type: string
+        blockReason:
+          type: string
+      required:
+        - shiftUuid
+        - workerUuid
+        - blockReason
+    GenericSuccessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+      required:
+        - status
 paths:
   /:
     summary: The application health check
@@ -256,7 +291,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  shifts:
+                  shiftAssignments:
                     type: array
                     items:
                       $ref: '#/components/schemas/Shift'
@@ -287,3 +322,32 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Shift'
+
+/rate-worker:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RateWorkerInput'
+      responses:
+        '200':
+          description: Successfully rated a Worker for a Shift
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShiftAssignment'
+  /block-worker:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlockWorkerInput'
+      responses:
+        '200':
+          description: Successfully blocked a Worker from working shifts for a Healthcare facility
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericSuccessResponse'


### PR DESCRIPTION
Adds a “rating” column to the “ShiftAssignment” table, allowing workers to be rated by the facility they work at.

Adds a new “BlockedWorker” table to keep track of workers who have been blocked from working at a particular facility.

Updates controllers / services to support new rating & block features.